### PR TITLE
🐛 (publish_package.yml): Mudança no evento para ativar workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,6 +1,8 @@
 name: Publish package
 
 on:
+  workflow_dispatch:
+
   push:
     tags:
       - "v*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ Aqui estão todos os commits realizados até o momento, acompanhe todos eles na 
 
 **Commits:**
 
+- **0a2266c4b83244257e51f28d088aa824c0a1b11a**
+
+	Link para o commit: [Ver modificações do commit](https://github.com/MauMuller/valisk/commit/0a2266c4b83244257e51f28d088aa824c0a1b11a)
+
+	Autor: MauMuller - [https://github.com/MauMuller/](https://github.com/MauMuller/)
+
+	Data: 06/01/2023
+
+	```
+    💚 (publish-package.yml): Geração de arquivo de build quando o YML é executado para enviar para o NPM
+    
+    Foi apenas adicionado uma linha de build para gerar uma biblioteca minificada para o NPM
+	```
+
+<br />
+
 - **fc74da2bda74f5066619637ec6d34d80a328fb42**
 
 	Link para o commit: [Ver modificações do commit](https://github.com/MauMuller/valisk/commit/fc74da2bda74f5066619637ec6d34d80a328fb42)


### PR DESCRIPTION
Foi incrementado o workflow_dispatch novamente para que seja executado de forma manual essa parte de publicação da biblioteca, já que a API do github não consegue acionar o evento de forma automática

<div align="center">
  <h1>Pull Request</h1>
  <p align="justify">Este é apenas um template para que seja mais fácil a comunicação e entendimento das mudanças, por conta disso, existem alguns tópicos abaixos que serão obrigatórios de serem respondidos.</p>
  <p align="left"><b>Observações:</b></p>
  <p align="justify">Dentro do menu haverá alguns <code>textos</code> para os tópicos, <code>todos esses textos são ilustrativos</code>, escreva no lugar deles as suas mudanças.</p>
  <p align="justify">Todos os tópicos com <code>*</code> deverão ser respondidos de forma obrigatória, lembre-se disso.</p>
  <p align="justify">É possível incrementar mais tópicos e descrições, basta adicionar um link no menu.</p>
</div>

<br/><br/>

## Trata-se de qual categoria alteração?\*

- `FIX`;

<br/>

## Qual é o motivo das mudanças?\*

Não execução do YAML para publicação do pacote

<br/>

## O que você fez para resolver?\*

Precisei deixar o workflow de forma `manual`

---

<br/>

<div align="center"><h3>Obrigado pela contribuição! 😁😁</h3></div>

<br/>
